### PR TITLE
[FIX] 재로그인 관련한 예외처리, OAuth2.0 로그인시 토큰 반환 방식 지정 (#2)

### DIFF
--- a/src/main/java/com/project/trysketch/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/project/trysketch/global/jwt/JwtAuthFilter.java
@@ -1,7 +1,10 @@
 package com.project.trysketch.global.jwt;
 
+import ch.qos.logback.classic.helpers.MDCInsertingServletFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.trysketch.global.dto.MsgResponseDto;
+import com.project.trysketch.global.exception.CustomException;
+import com.project.trysketch.global.exception.StatusMsgCode;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,6 +13,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
+
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -29,20 +33,20 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         String token = jwtUtil.resolveToken(request);
 
-        if(token != null) {
-            if(!jwtUtil.validateToken(token)){
+        if (token != null) {
+            if (!jwtUtil.validateToken(token)) {
                 jwtExceptionHandler(response, "Token Error", HttpStatus.UNAUTHORIZED.value());
                 return;
             }
             Claims info = jwtUtil.getUserInfoFromToken(token);
-            setAuthentication(info.getSubject());
+            setAuthentication(info.get("email").toString());
         }
-        filterChain.doFilter(request,response);
+        filterChain.doFilter(request, response);
     }
 
-    public void setAuthentication(String username) {
+    public void setAuthentication(String email) {
         SecurityContext context = SecurityContextHolder.createEmptyContext();
-        Authentication authentication = jwtUtil.createAuthentication(username);
+        Authentication authentication = jwtUtil.createAuthentication(email);
         context.setAuthentication(authentication);
 
         SecurityContextHolder.setContext(context);

--- a/src/main/java/com/project/trysketch/global/jwt/JwtUtil.java
+++ b/src/main/java/com/project/trysketch/global/jwt/JwtUtil.java
@@ -96,8 +96,8 @@ public class JwtUtil {
 
 
     // 인증 객체를 실제로 만드는 부분
-    public Authentication createAuthentication(String nickname) {
-        UserDetails userDetails = userDetailsServiceImpl.loadUserByUsername(nickname);
+    public Authentication createAuthentication(String email) {
+        UserDetails userDetails = userDetailsServiceImpl.loadUserByUsername(email);
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 }

--- a/src/main/java/com/project/trysketch/global/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/project/trysketch/global/security/UserDetailsServiceImpl.java
@@ -17,8 +17,8 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String nickname) throws UsernameNotFoundException {
-        User user = userRepository.findByNickname(nickname)
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
                 .orElseThrow(()-> new IllegalArgumentException("없는 유저"));
 
         return new UserDetailsImpl(user, user.getNickname());

--- a/src/main/java/com/project/trysketch/user/controller/UserController.java
+++ b/src/main/java/com/project/trysketch/user/controller/UserController.java
@@ -57,13 +57,7 @@ public class UserController {
     @GetMapping("/kakao/callback")
     public ResponseEntity<MsgResponseDto> kakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
         // code: 카카오 서버로부터 받은 인가 코드
-        String createToken = kakaoService.kakaoLogin(code, response);
-
-        // Cookie 생성 및 직접 브라우저에 Set
-        Cookie cookie = new Cookie(JwtUtil.AUTHORIZATION_HEADER, createToken.substring(7));
-        cookie.setPath("/");
-        response.addCookie(cookie);
-
+        kakaoService.kakaoLogin(code, response);
         return ResponseEntity.ok(new MsgResponseDto(StatusMsgCode.LOG_IN));
     }
 

--- a/src/main/java/com/project/trysketch/user/service/KakaoService.java
+++ b/src/main/java/com/project/trysketch/user/service/KakaoService.java
@@ -3,6 +3,8 @@ package com.project.trysketch.user.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.trysketch.global.exception.CustomException;
+import com.project.trysketch.global.exception.StatusMsgCode;
 import com.project.trysketch.global.jwt.JwtUtil;
 import com.project.trysketch.user.dto.KakaoUserRequstDto;
 import com.project.trysketch.user.entity.User;
@@ -34,19 +36,19 @@ public class KakaoService {
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
 
-    public String kakaoLogin(String code, HttpServletResponse response) throws JsonProcessingException {
+    public void kakaoLogin(String code, HttpServletResponse response) throws JsonProcessingException {
         // 1. "인가 코드"로 "액세스 토큰" 요청
-        String accessToken = getToken(code);                              // 포스트맨 확인위해 주석처리 해둠.
+        String accessToken = getToken(code);                                           // 포스트맨 확인위해 주석처리 필요
 
         // 2. 토큰으로 카카오 API 호출 : "액세스 토큰"으로 "카카오 사용자 정보" 가져오기
-        KakaoUserRequstDto kakaoUserInfo = getKakaoUserInfo(accessToken);            // 포스트맨 확인위해 accessToken에서 code로 바꿔둠
+        KakaoUserRequstDto kakaoUserInfo = getKakaoUserInfo(accessToken);             // 포스트맨 확인위해 accessToken에서 code로 바꿔야함
 
         // 3. 필요시에 회원가입
         User kakaoUser = registerKakaoUserIfNeeded(kakaoUserInfo);
 
         // 4. JWT 토큰 반환
         String createToken =  jwtUtil.createToken(kakaoUser.getEmail(), kakaoUser.getNickname());
-        return createToken;
+        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, createToken);
     }
 
     // 1. "인가 코드"로 "액세스 토큰" 요청
@@ -59,7 +61,8 @@ public class KakaoService {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
         body.add("client_id", "99896cbca8689b2a7b2513df031382da");
-        body.add("redirect_uri", "http://localhost:8080/api/user/kakao/callback");
+        // body.add("redirect_uri", "http://localhost:8080/api/user/kakao/callback");  // 포스트맨 실험
+        body.add("redirect_uri", "http://localhost:3030/login");                       // 프론트의 주소
         body.add("code", code);
 
         // HTTP 요청 보내기
@@ -118,7 +121,9 @@ public class KakaoService {
         if (kakaoUser == null) {
             // 카카오 사용자 email 동일한 email 가진 회원이 있는지 확인
             String kakaoEmail = kakaoUserInfo.getEmail();
+
             User sameEmailUser = userRepository.findByEmail(kakaoEmail).orElse(null);
+
             if (sameEmailUser != null) {
                 kakaoUser = sameEmailUser;
                 // 기존 회원정보에 카카오 Id 추가
@@ -129,8 +134,8 @@ public class KakaoService {
                 String encodedPassword = passwordEncoder.encode(password);
                 String email = kakaoUserInfo.getEmail();
 
-                kakaoUser = User.builder().email(email)
-                        .password(encodedPassword)
+                kakaoUser = User.builder().email(encodedPassword)
+                        .password(password)
                         .kakaoId(kakaoId)
                         .kakaoNickname(kakaoUserInfo.getNickname())
                         .build();


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
feature/2 -> develop

### 변경 사항
- 로그인해서 토큰 가지고 있는 경우에 재로그인 시도시 발생하는 예외 처리
-  OAuth2.0 로그인시 JWT토큰을 서버에서 쿠키에 직접 저장하는 방식에서, JWT토큰을 클라이언트에 보낸 다음에 클라이언트에서 직접 쿠키를 저장하는 방식으로 변경

### 테스트 결과
Postman 테스트 결과 이상 없습니다