### PR TITLE
[REFACTOR] S3업로드 다수의 이미지에서 한 개의 이미지로 바꿈, 주석추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,10 @@ dependencies {
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 
+    // s3 설정 관련
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 }

--- a/src/main/java/com/project/trysketch/global/exception/StatusMsgCode.java
+++ b/src/main/java/com/project/trysketch/global/exception/StatusMsgCode.java
@@ -20,6 +20,8 @@ public enum StatusMsgCode {
     PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "게시글을 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "댓글을 찾을 수 없습니다."),
     INVALID_USER(HttpStatus.BAD_REQUEST, "작성자만 삭제/수정할 수 있습니다."),
+    IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "이미지를 찾을 수 없습니다."),
+    ALREADY_CLICKED_LIKE(HttpStatus.BAD_REQUEST, "이미 좋아요를 눌렀습니다."),
 
     //    /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
 //    INVALID_AUTH_TOKEN(HttpStatus.UNAUTHORIZED, "권한 정보가 없는 토큰입니다."),
@@ -42,7 +44,8 @@ public enum StatusMsgCode {
     LIKE(HttpStatus.OK, "좋아요 성공"),
     CANCEL_LIKE(HttpStatus.OK, "좋아요 취소"),
     DELETE_POST(HttpStatus.OK, "게시글을 삭제하였습니다"),
-    DELETE_COMMENT(HttpStatus.OK, "댓글을 삭제하였습니다");
+    DELETE_COMMENT(HttpStatus.OK, "댓글을 삭제하였습니다"),
+    DONE_LIKE(HttpStatus.OK, "좋아요 클릭 완료");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/project/trysketch/image/AmazonS3Service.java
+++ b/src/main/java/com/project/trysketch/image/AmazonS3Service.java
@@ -33,12 +33,12 @@ public class AmazonS3Service {
     public String bucket;
 
     // 이미지 업로드 (S3, DB)
-    public void upload(List<MultipartFile> multipartFilelist, String dirName, User user) throws IOException {
+    public void upload(ImageLikeRequestDto requestDto, List<MultipartFile> multipartFilelist, String dirName, User user) throws IOException {
 
         for (MultipartFile multipartFile : multipartFilelist){
             if (multipartFile != null){
                 File uploadFile = convert(multipartFile).orElseThrow(() -> new IllegalArgumentException("파일 전환 실패"));
-                ImageFile imageFile = new ImageFile(upload(uploadFile, dirName), user);
+                ImageFile imageFile = new ImageFile(upload(uploadFile, dirName), user, requestDto.getPainter());
                 imageFileRepository.save(imageFile);
             }
         }

--- a/src/main/java/com/project/trysketch/image/AmazonS3Service.java
+++ b/src/main/java/com/project/trysketch/image/AmazonS3Service.java
@@ -16,6 +16,10 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
 
+
+// 1. 기능   : S3 업로드 로직
+// 2. 작성자 : 황미경
+
 @Slf4j
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/project/trysketch/image/AmazonS3Service.java
+++ b/src/main/java/com/project/trysketch/image/AmazonS3Service.java
@@ -2,7 +2,6 @@ package com.project.trysketch.image;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.project.trysketch.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -11,11 +10,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -25,7 +22,6 @@ import java.util.UUID;
 @Service
 public class AmazonS3Service {
 
-
     private final AmazonS3Client amazonS3Client;
     private final ImageFileRepository imageFileRepository;
 
@@ -33,14 +29,11 @@ public class AmazonS3Service {
     public String bucket;
 
     // 이미지 업로드 (S3, DB)
-    public void upload(ImageLikeRequestDto requestDto, List<MultipartFile> multipartFilelist, String dirName, User user) throws IOException {
-
-        for (MultipartFile multipartFile : multipartFilelist){
-            if (multipartFile != null){
-                File uploadFile = convert(multipartFile).orElseThrow(() -> new IllegalArgumentException("파일 전환 실패"));
-                ImageFile imageFile = new ImageFile(upload(uploadFile, dirName), user, requestDto.getPainter());
-                imageFileRepository.save(imageFile);
-            }
+    public void upload(ImageLikeRequestDto requestDto, MultipartFile multipartFile, String dirName, User user) throws IOException {
+        if (multipartFile != null) {
+            File uploadFile = convert(multipartFile).orElseThrow(() -> new IllegalArgumentException("파일 전환 실패"));
+            ImageFile imageFile = new ImageFile(upload(uploadFile, dirName), user, requestDto.getPainter());
+            imageFileRepository.save(imageFile);
         }
     }
 
@@ -75,12 +68,6 @@ public class AmazonS3Service {
             }
             return Optional.of(convertFile);
         }
-
         return Optional.empty();
-    }
-
-    // find image from s3
-    public String getThumbnailPath(String path) {
-        return amazonS3Client.getUrl(bucket, path).toString();
     }
 }

--- a/src/main/java/com/project/trysketch/image/AmazonS3Service.java
+++ b/src/main/java/com/project/trysketch/image/AmazonS3Service.java
@@ -1,0 +1,86 @@
+package com.project.trysketch.image;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.project.trysketch.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Service
+public class AmazonS3Service {
+
+
+    private final AmazonS3Client amazonS3Client;
+    private final ImageFileRepository imageFileRepository;
+
+    @Value("${cloud.aws.s3.bucket}")         // bucket 이름
+    public String bucket;
+
+    // 이미지 업로드 (S3, DB)
+    public void upload(List<MultipartFile> multipartFilelist, String dirName, User user) throws IOException {
+
+        for (MultipartFile multipartFile : multipartFilelist){
+            if (multipartFile != null){
+                File uploadFile = convert(multipartFile).orElseThrow(() -> new IllegalArgumentException("파일 전환 실패"));
+                ImageFile imageFile = new ImageFile(upload(uploadFile, dirName), user);
+                imageFileRepository.save(imageFile);
+            }
+        }
+    }
+
+    // S3로 파일 업로드하기 (파일이름 지정, 파일 업로드, 로컬파일 삭제)
+    private String upload(File uploadFile, String dirName) {
+        String fileName = dirName + "/" + UUID.randomUUID();     // S3에 저장될 파일 이름
+        String uploadImageUrl = putS3(uploadFile, fileName);     // s3로 업로드
+        removeNewFile(uploadFile);                               // 로컬에 저장된 파일 지우기
+        return uploadImageUrl;
+    }
+
+    // S3로 업로드
+    private String putS3(File uploadFile, String fileName) {
+        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(CannedAccessControlList.PublicRead));
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    // 로컬에 저장된 이미지 지우기
+    private void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            log.info("File delete success");
+            return;
+        }
+        log.info("File delete fail");
+    }
+
+    private Optional<File> convert(MultipartFile multipartFile) throws IOException {
+        File convertFile = new File(multipartFile.getOriginalFilename());
+        if (convertFile.createNewFile()) {
+            try (FileOutputStream fos = new FileOutputStream(convertFile)) { // FileOutputStream 데이터를 파일에 바이트 스트림으로 저장하기 위함
+                fos.write(multipartFile.getBytes());
+            }
+            return Optional.of(convertFile);
+        }
+
+        return Optional.empty();
+    }
+
+    // find image from s3
+    public String getThumbnailPath(String path) {
+        return amazonS3Client.getUrl(bucket, path).toString();
+    }
+}

--- a/src/main/java/com/project/trysketch/image/ImageFile.java
+++ b/src/main/java/com/project/trysketch/image/ImageFile.java
@@ -12,18 +12,17 @@ import javax.persistence.*;
 public class ImageFile {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;                    // id
+    private Long id;                     // id
 
-    @Column(nullable = false)           // image 경로
+    @Column(nullable = false)            // image 경로
     private String path;
 
-    @Column(nullable = false)
+    @Column(nullable = false)            // 그림 그린 사람
     private String painter;
-
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
-    private User user;                  // userid
+    private User user;                   // 좋아요 누른 사람
 
     //생성자
     public ImageFile(String path, User user, String painter) {

--- a/src/main/java/com/project/trysketch/image/ImageFile.java
+++ b/src/main/java/com/project/trysketch/image/ImageFile.java
@@ -1,0 +1,30 @@
+package com.project.trysketch.image;
+
+import com.project.trysketch.user.entity.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class ImageFile {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;                    // id
+
+    @Column(nullable = false)           // image 경로
+    private String path;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;                  // userid
+
+
+    //생성자
+    public ImageFile(String path, User user) {
+        this.path = path;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/project/trysketch/image/ImageFile.java
+++ b/src/main/java/com/project/trysketch/image/ImageFile.java
@@ -17,14 +17,18 @@ public class ImageFile {
     @Column(nullable = false)           // image 경로
     private String path;
 
+    @Column(nullable = false)
+    private String painter;
+
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;                  // userid
 
-
     //생성자
-    public ImageFile(String path, User user) {
+    public ImageFile(String path, User user, String painter) {
         this.path = path;
         this.user = user;
+        this.painter = painter;
     }
 }

--- a/src/main/java/com/project/trysketch/image/ImageFile.java
+++ b/src/main/java/com/project/trysketch/image/ImageFile.java
@@ -6,6 +6,10 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+
+// 1. 기능   : ImageFile 구성요소
+// 2. 작성자 : 황미경
+
 @Getter
 @Entity
 @NoArgsConstructor

--- a/src/main/java/com/project/trysketch/image/ImageFileRepository.java
+++ b/src/main/java/com/project/trysketch/image/ImageFileRepository.java
@@ -2,7 +2,9 @@ package com.project.trysketch.image;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 
 public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {
+    List<ImageFile> findByUserId(Long userId);
 
 }

--- a/src/main/java/com/project/trysketch/image/ImageFileRepository.java
+++ b/src/main/java/com/project/trysketch/image/ImageFileRepository.java
@@ -1,7 +1,6 @@
 package com.project.trysketch.image;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 
 public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {

--- a/src/main/java/com/project/trysketch/image/ImageFileRepository.java
+++ b/src/main/java/com/project/trysketch/image/ImageFileRepository.java
@@ -3,6 +3,9 @@ package com.project.trysketch.image;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
+
+// 1. 기능   : ImageFile Repository
+// 2. 작성자 : 황미경
 public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {
     List<ImageFile> findByUserId(Long userId);
 

--- a/src/main/java/com/project/trysketch/image/ImageFileRepository.java
+++ b/src/main/java/com/project/trysketch/image/ImageFileRepository.java
@@ -1,0 +1,8 @@
+package com.project.trysketch.image;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {
+
+}

--- a/src/main/java/com/project/trysketch/image/ImageLikeController.java
+++ b/src/main/java/com/project/trysketch/image/ImageLikeController.java
@@ -1,0 +1,29 @@
+package com.project.trysketch.image;
+
+import com.project.trysketch.global.dto.MsgResponseDto;
+import com.project.trysketch.global.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/image")
+public class ImageLikeController {
+    private final ImageLikeService imageLikeService;
+
+    // 이미지 좋아요 클릭시 S3에 업로드
+    @PostMapping(value = "/like",consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<MsgResponseDto> imageLike(@RequestPart(value = "file") List<MultipartFile> multipartFilelist,
+                                                    @AuthenticationPrincipal UserDetailsImpl userDetails) throws IOException {
+        return ResponseEntity.ok(imageLikeService.saveLike(multipartFilelist, userDetails.getUser()));
+    }
+}

--- a/src/main/java/com/project/trysketch/image/ImageLikeController.java
+++ b/src/main/java/com/project/trysketch/image/ImageLikeController.java
@@ -11,6 +11,10 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.List;
 
+
+// 1. 기능   : ImageLike 컨트롤러
+// 2. 작성자 : 황미경
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")

--- a/src/main/java/com/project/trysketch/image/ImageLikeController.java
+++ b/src/main/java/com/project/trysketch/image/ImageLikeController.java
@@ -6,10 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.List;
@@ -21,9 +18,21 @@ public class ImageLikeController {
     private final ImageLikeService imageLikeService;
 
     // 이미지 좋아요 클릭시 S3에 업로드
-    @PostMapping(value = "/like",consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
-    public ResponseEntity<MsgResponseDto> imageLike(@RequestPart(value = "file") List<MultipartFile> multipartFilelist,
+    @PostMapping(value = "/like",consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<MsgResponseDto> imageLike(@RequestPart(value = "data") ImageLikeRequestDto requestDto,
+                                                    @RequestPart(value = "file") List<MultipartFile> multipartFilelist,
                                                     @AuthenticationPrincipal UserDetailsImpl userDetails) throws IOException {
-        return ResponseEntity.ok(imageLikeService.saveLike(multipartFilelist, userDetails.getUser()));
+        return ResponseEntity.ok(imageLikeService.saveImage(requestDto, multipartFilelist, userDetails.getUser()));
     }
+
+
+    // 마이페이지에서 좋아요 누른 사진 조회
+    @GetMapping("/like")
+    public List<String> getImageLike(@AuthenticationPrincipal UserDetailsImpl userDetails)  {
+        return imageLikeService.getImage(userDetails.getUser());
+    }
+
+
+
+
 }

--- a/src/main/java/com/project/trysketch/image/ImageLikeController.java
+++ b/src/main/java/com/project/trysketch/image/ImageLikeController.java
@@ -13,26 +13,22 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/image")
+@RequestMapping("/api")
 public class ImageLikeController {
     private final ImageLikeService imageLikeService;
 
     // 이미지 좋아요 클릭시 S3에 업로드
-    @PostMapping(value = "/like",consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(value = "/image/like", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<MsgResponseDto> imageLike(@RequestPart(value = "data") ImageLikeRequestDto requestDto,
-                                                    @RequestPart(value = "file") List<MultipartFile> multipartFilelist,
+                                                    @RequestPart(value = "file") MultipartFile multipartFile,
                                                     @AuthenticationPrincipal UserDetailsImpl userDetails) throws IOException {
-        return ResponseEntity.ok(imageLikeService.saveImage(requestDto, multipartFilelist, userDetails.getUser()));
+        return ResponseEntity.ok(imageLikeService.saveImage(requestDto, multipartFile, userDetails.getUser()));
     }
 
 
     // 마이페이지에서 좋아요 누른 사진 조회
-    @GetMapping("/like")
-    public List<String> getImageLike(@AuthenticationPrincipal UserDetailsImpl userDetails)  {
-        return imageLikeService.getImage(userDetails.getUser());
+    @GetMapping("/mypage/image-like")
+    public ResponseEntity<List<String>> getImageLike(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseEntity.ok(imageLikeService.getImage(userDetails.getUser()));
     }
-
-
-
-
 }

--- a/src/main/java/com/project/trysketch/image/ImageLikeRequestDto.java
+++ b/src/main/java/com/project/trysketch/image/ImageLikeRequestDto.java
@@ -8,5 +8,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ImageLikeRequestDto {
-    private String painter;
+    private String painter;        // 그림 그린 사람
 }

--- a/src/main/java/com/project/trysketch/image/ImageLikeRequestDto.java
+++ b/src/main/java/com/project/trysketch/image/ImageLikeRequestDto.java
@@ -1,0 +1,12 @@
+package com.project.trysketch.image;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ImageLikeRequestDto {
+    private String painter;
+}

--- a/src/main/java/com/project/trysketch/image/ImageLikeRequestDto.java
+++ b/src/main/java/com/project/trysketch/image/ImageLikeRequestDto.java
@@ -4,6 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+
+// 1. 기능   : ImageLike 입력요소
+// 2. 작성자 : 황미경
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/com/project/trysketch/image/ImageLikeService.java
+++ b/src/main/java/com/project/trysketch/image/ImageLikeService.java
@@ -11,6 +11,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+
+// 1. 기능   : ImageLike 서비스
+// 2. 작성자 : 황미경
+
 @Service
 @RequiredArgsConstructor
 public class ImageLikeService {

--- a/src/main/java/com/project/trysketch/image/ImageLikeService.java
+++ b/src/main/java/com/project/trysketch/image/ImageLikeService.java
@@ -1,0 +1,32 @@
+package com.project.trysketch.image;
+
+import com.project.trysketch.global.dto.MsgResponseDto;
+import com.project.trysketch.global.exception.CustomException;
+import com.project.trysketch.global.exception.StatusMsgCode;
+import com.project.trysketch.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ImageLikeService {
+
+    private final AmazonS3Service s3Service;
+    //숙소 정보 작성
+    public MsgResponseDto saveLike(List<MultipartFile> multipartFilelist, User user) throws IOException {
+
+        if (multipartFilelist != null) {
+            s3Service.upload(multipartFilelist, "static", user);
+
+        }
+        return new MsgResponseDto(StatusMsgCode.DONE_LIKE);
+    }
+
+
+}

--- a/src/main/java/com/project/trysketch/image/ImageLikeService.java
+++ b/src/main/java/com/project/trysketch/image/ImageLikeService.java
@@ -1,20 +1,15 @@
 package com.project.trysketch.image;
 
 import com.project.trysketch.global.dto.MsgResponseDto;
-import com.project.trysketch.global.exception.CustomException;
 import com.project.trysketch.global.exception.StatusMsgCode;
 import com.project.trysketch.user.entity.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
 import java.io.IOException;
-import java.sql.Array;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,21 +19,24 @@ public class ImageLikeService {
     private final ImageFileRepository imageFileRepository;
 
     // S3에 이미지 저장
-    public MsgResponseDto saveImage(ImageLikeRequestDto requestDto, List<MultipartFile> multipartFilelist, User user) throws IOException {
-        if (multipartFilelist != null) {
-            s3Service.upload(requestDto, multipartFilelist, "static", user);
+    public MsgResponseDto saveImage(ImageLikeRequestDto requestDto, MultipartFile multipartFile, User user) throws IOException {
+        if (multipartFile != null) {
+            s3Service.upload(requestDto, multipartFile, "static", user);
         }
         return new MsgResponseDto(StatusMsgCode.DONE_LIKE);
     }
 
+
+    // S3에 업로드 된 이미지 조회
     @Transactional(readOnly = true)
     public List<String> getImage(User user) {
+        // User가 좋아요 누른 그림 DB로부터 불러오기
         List<String> imagePathList = new ArrayList<>();
         List<ImageFile> imageFileList = imageFileRepository.findByUserId(user.getId());
-            for(ImageFile imageFile : imageFileList) {
-                imagePathList.add(imageFile.getPath());
-            }
-        return imagePathList;
 
+        for (ImageFile imageFile : imageFileList) {
+            imagePathList.add(imageFile.getPath());
+        }
+        return imagePathList;
     }
 }

--- a/src/main/java/com/project/trysketch/image/ImageLikeService.java
+++ b/src/main/java/com/project/trysketch/image/ImageLikeService.java
@@ -5,11 +5,14 @@ import com.project.trysketch.global.exception.CustomException;
 import com.project.trysketch.global.exception.StatusMsgCode;
 import com.project.trysketch.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.sql.Array;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,15 +21,24 @@ import java.util.Optional;
 public class ImageLikeService {
 
     private final AmazonS3Service s3Service;
-    //숙소 정보 작성
-    public MsgResponseDto saveLike(List<MultipartFile> multipartFilelist, User user) throws IOException {
+    private final ImageFileRepository imageFileRepository;
 
+    // S3에 이미지 저장
+    public MsgResponseDto saveImage(ImageLikeRequestDto requestDto, List<MultipartFile> multipartFilelist, User user) throws IOException {
         if (multipartFilelist != null) {
-            s3Service.upload(multipartFilelist, "static", user);
-
+            s3Service.upload(requestDto, multipartFilelist, "static", user);
         }
         return new MsgResponseDto(StatusMsgCode.DONE_LIKE);
     }
 
+    @Transactional(readOnly = true)
+    public List<String> getImage(User user) {
+        List<String> imagePathList = new ArrayList<>();
+        List<ImageFile> imageFileList = imageFileRepository.findByUserId(user.getId());
+            for(ImageFile imageFile : imageFileList) {
+                imagePathList.add(imageFile.getPath());
+            }
+        return imagePathList;
 
+    }
 }

--- a/src/main/java/com/project/trysketch/user/controller/UserController.java
+++ b/src/main/java/com/project/trysketch/user/controller/UserController.java
@@ -12,8 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.profiles.active=rds
+spring.profiles.include=jwt

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-spring.profiles.active=rds
-spring.profiles.include=jwt


### PR DESCRIPTION
### PR 타입
- [x] 코드 리팩토링

### 반영 브랜치
feature/s3 -> develop

### 변경 사항
- 기존 여러 파일 업로드에서 한개의 파일 업로드로 변경
- 이미지 테이블에 그린사람 닉네임 저장시, 직관적으로 볼 수 있도록 nickname에서 painter로 변경
- restful한 설계위해 URL 변경
- 주석추가

### 테스트 결과
Postman 테스트 결과 이상 없습니다