### PR TITLE
[FEAT] OAuth2.0 카카오톡 로그인 시 랜덤 닉네임 부여

### DIFF
--- a/src/main/java/com/project/trysketch/user/repository/RandomNickRepository.java
+++ b/src/main/java/com/project/trysketch/user/repository/RandomNickRepository.java
@@ -7,6 +7,6 @@ import java.util.Optional;
 
 // 1. 기능   : 랜덤 닉네임 Repository
 // 2. 작성자 : 서혁수
-public interface RandomNickRepository extends JpaRepository<RandomNick, Long> {
+public interface RandomNickRepository extends JpaRepository<RandomNick, Integer> {
     Optional<RandomNick> findByNum(int num);
 }

--- a/src/main/java/com/project/trysketch/user/service/KakaoService.java
+++ b/src/main/java/com/project/trysketch/user/service/KakaoService.java
@@ -38,16 +38,17 @@ public class KakaoService {
 
     public void kakaoLogin(String code, HttpServletResponse response) throws JsonProcessingException {
         // 1. "인가 코드"로 "액세스 토큰" 요청
-        String accessToken = getToken(code);                                           // 포스트맨 확인위해 주석처리 필요
+//        String accessToken = getToken(code);                                           // 포스트맨 확인위해 주석처리 필요
 
         // 2. 토큰으로 카카오 API 호출 : "액세스 토큰"으로 "카카오 사용자 정보" 가져오기
-        KakaoUserRequstDto kakaoUserInfo = getKakaoUserInfo(accessToken);             // 포스트맨 확인위해 accessToken에서 code로 바꿔야함
+        KakaoUserRequstDto kakaoUserInfo = getKakaoUserInfo(code);             // 포스트맨 확인위해 accessToken에서 code로 바꿔야함
 
         // 3. 필요시에 회원가입
         User kakaoUser = registerKakaoUserIfNeeded(kakaoUserInfo);
 
         // 4. JWT 토큰 반환
-        String createToken =  jwtUtil.createToken(kakaoUser.getEmail(), kakaoUser.getNickname());
+        String nickname = "나는야 피카소";
+        String createToken =  jwtUtil.createToken(kakaoUser.getEmail(), nickname);
         response.addHeader(JwtUtil.AUTHORIZATION_HEADER, createToken);
     }
 
@@ -134,10 +135,11 @@ public class KakaoService {
                 String encodedPassword = passwordEncoder.encode(password);
                 String email = kakaoUserInfo.getEmail();
 
-                kakaoUser = User.builder().email(encodedPassword)
-                        .password(password)
+                kakaoUser = User.builder()
+                        .password(encodedPassword)
                         .kakaoId(kakaoId)
                         .kakaoNickname(kakaoUserInfo.getNickname())
+                        .email(email)
                         .build();
             }
             userRepository.save(kakaoUser);

--- a/src/main/java/com/project/trysketch/user/service/UserService.java
+++ b/src/main/java/com/project/trysketch/user/service/UserService.java
@@ -1,6 +1,5 @@
 package com.project.trysketch.user.service;
 
-import com.project.trysketch.redis.service.RedisService;
 import com.project.trysketch.user.entity.RandomNick;
 import com.project.trysketch.user.repository.RandomNickRepository;
 import com.project.trysketch.global.dto.MsgResponseDto;
@@ -16,7 +15,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -88,7 +86,7 @@ public class UserService {
 
     // 랜덤 닉네임 발급
     public String RandomNick() {
-        int num = (int) (Math.random() * 1000);
+        int num = (int) (Math.random() * 1000 +1);
         RandomNick randomNick = randomNickRepository.findByNum(num).orElse(null);
 
         return Objects.requireNonNull(randomNick).getNickname();


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feature/12 -> develop

### 변경 사항
- 기존 카카오톡의 유저 정보 중 닉네임을 가져오던 것을, DB에 저장된 닉네임 랜덤으로 부여

### 테스트 결과
Postman 테스트 결과 이상 없습니다
