### PR TITLE
[FEAT] Scheduler 이용해서 좋아요 안눌린 S3의 그림 주기적으로 삭제하는 기능 (#29)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,6 @@ dependencies {
 
     // Json
     implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
-
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/trysketch/TrysKetchApplication.java
+++ b/src/main/java/com/project/trysketch/TrysKetchApplication.java
@@ -2,11 +2,13 @@ package com.project.trysketch;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
 @EnableJpaAuditing
+@EnableCaching
 @SpringBootApplication
 public class TrysKetchApplication {
 

--- a/src/main/java/com/project/trysketch/TrysKetchApplication.java
+++ b/src/main/java/com/project/trysketch/TrysKetchApplication.java
@@ -2,11 +2,11 @@ package com.project.trysketch;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
-@EnableCaching
 @SpringBootApplication
 public class TrysKetchApplication {
 

--- a/src/main/java/com/project/trysketch/global/exception/StatusMsgCode.java
+++ b/src/main/java/com/project/trysketch/global/exception/StatusMsgCode.java
@@ -55,7 +55,8 @@ public enum StatusMsgCode {
     DELETE_COMMENT(HttpStatus.OK, "댓글을 삭제하였습니다"),
     DONE_LIKE(HttpStatus.OK, "좋아요 클릭 완료"),
     LIKE_IMAGE(HttpStatus.OK, "좋아요 완료"),
-    DONE_DRAWING(HttpStatus.OK, "사진 저장 완료");
+    DONE_DRAWING(HttpStatus.OK, "사진 저장 완료"),
+    DELETE_IMAGE(HttpStatus.OK, "사진 삭제 완료");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/project/trysketch/image/AmazonS3Service.java
+++ b/src/main/java/com/project/trysketch/image/AmazonS3Service.java
@@ -2,6 +2,7 @@ package com.project.trysketch.image;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.project.trysketch.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -53,6 +54,12 @@ public class AmazonS3Service {
     private String putS3(File uploadFile, String fileName) {
         amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(CannedAccessControlList.PublicRead));
         return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    // S3 이미지 삭제
+    public void delete(String fileName){
+        DeleteObjectRequest request = new DeleteObjectRequest(bucket, fileName);
+        amazonS3Client.deleteObject(request);
     }
 
     // 로컬에 저장된 이미지 지우기

--- a/src/main/java/com/project/trysketch/image/Image.java
+++ b/src/main/java/com/project/trysketch/image/Image.java
@@ -1,10 +1,10 @@
 package com.project.trysketch.image;
 
-import com.project.trysketch.user.entity.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 
 // 1. 기능   : ImageFile 구성요소
@@ -23,6 +23,10 @@ public class Image {
 
     @Column(nullable = false)            // 그린사람의 닉네임
     private String painter;
+
+    @OneToMany(mappedBy = "image")
+    private List<ImageLike> imageLikes = new ArrayList<>();
+
 
     //생성자
     public Image(String path, String painter) {

--- a/src/main/java/com/project/trysketch/image/ImageController.java
+++ b/src/main/java/com/project/trysketch/image/ImageController.java
@@ -1,14 +1,11 @@
 package com.project.trysketch.image;
 
 import com.project.trysketch.global.dto.MsgResponseDto;
-import com.project.trysketch.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.List;
@@ -49,6 +46,4 @@ public class ImageController {
                                                      HttpServletRequest request) {
         return ResponseEntity.ok(imageService.cancelLike(imageId, request));
     }
-
-
 }

--- a/src/main/java/com/project/trysketch/image/ImageLike.java
+++ b/src/main/java/com/project/trysketch/image/ImageLike.java
@@ -3,8 +3,10 @@ package com.project.trysketch.image;
 import com.project.trysketch.user.entity.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 import javax.persistence.*;
+
+// 1. 기능   : ImageLike 요소
+// 2. 작성자 : 황미경
 
 @Entity
 @Getter

--- a/src/main/java/com/project/trysketch/image/ImageLikeRepository.java
+++ b/src/main/java/com/project/trysketch/image/ImageLikeRepository.java
@@ -1,9 +1,11 @@
 package com.project.trysketch.image;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.Optional;
+
+// 1. 기능   : ImageRepository
+// 2. 작성자 : 황미경
 
 public interface ImageLikeRepository extends JpaRepository<ImageLike, Long> {
 

--- a/src/main/java/com/project/trysketch/image/ImageRepository.java
+++ b/src/main/java/com/project/trysketch/image/ImageRepository.java
@@ -1,11 +1,10 @@
 package com.project.trysketch.image;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.List;
-
 
 // 1. 기능   : ImageFile Repository
 // 2. 작성자 : 황미경
+
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
 }

--- a/src/main/java/com/project/trysketch/image/ImageService.java
+++ b/src/main/java/com/project/trysketch/image/ImageService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -77,12 +78,12 @@ public class ImageService {
         List<String> imagePathList = new ArrayList<>();
         for (ImageLike imageLike : imageLikeList) {
             imagePathList.add(imageLike.getImage().getPath());
-                    }
+        }
         return imagePathList;
     }
 
 
-    //좋아요 여부 확인
+    // 좋아요 여부 확인
     @Transactional(readOnly = true)
     public boolean checkLike(Long imageId, HttpServletRequest request) {
         Claims claims = jwtUtil.authorizeToken(request);
@@ -95,7 +96,7 @@ public class ImageService {
     }
 
 
-    //좋아요 삭제
+    // 좋아요 삭제
     @Transactional
     public MsgResponseDto cancelLike(Long imageId, HttpServletRequest request) {
         Claims claims = jwtUtil.authorizeToken(request);
@@ -118,8 +119,8 @@ public class ImageService {
     @Transactional
     public MsgResponseDto deleteImage() {
         List<Image> imageList = imageRepository.findAll();
-        for(Image image : imageList) {
-            if(image.getImageLikes().size()==0) {
+        for (Image image : imageList) {
+            if (image.getImageLikes().size() == 0) {
                 imageRepository.delete(image);
                 String path = image.getPath();
                 String filename = path.substring(62);

--- a/src/main/java/com/project/trysketch/image/Scheduler.java
+++ b/src/main/java/com/project/trysketch/image/Scheduler.java
@@ -1,0 +1,26 @@
+package com.project.trysketch.image;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+// 1. 기능   : Scheduler
+// 2. 작성자 : 황미경
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class Scheduler {
+
+    private final ImageService imageService;
+
+    // 좋아요 안 눌린 그림 DB, S3로 부터 주기적으로 삭제하는 기능. 우선은 테스트 위해 2분 단위로 삭제하도록 설정함
+    @Scheduled(cron = "0 0/2 * * * *")               // 초, 분, 시, 일, 월, 주 순서
+    public void deleteImage() {
+            imageService.deleteImage();
+
+        System.out.println("좋아요 안눌린 이미지 삭제. 2분마다 실행");
+        log.info("좋아요 안눌린 이미지 삭제. 2분마다 실행");
+    }
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feature/29-> develop

### 변경 사항
- Scheduler 이용해서 좋아요 안눌린 S3의 그림 주기적으로 삭제하는 기능 추가
- 파일 삭제 주기에 대해서는 정해진 바 없어, 테스트위해 2분으로 임시로 설정해둠
 
### 테스트 결과
DB 뿐 아니라 S3에서 파일 삭제되는 것 확인하였습니다
Postman 테스트 결과 이상 없습니다