### PR TITLE
[FEAT]  닉네임, 방제목 정규식 적용 (#73)

### DIFF
--- a/src/main/java/com/project/trysketch/controller/GameRoomController.java
+++ b/src/main/java/com/project/trysketch/controller/GameRoomController.java
@@ -12,6 +12,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 import java.util.Map;
 
 // 1. 기능    : 게임 방 컨트롤러
@@ -32,7 +33,7 @@ public class GameRoomController {
 
     // 게임 방 생성
     @PostMapping("/room")
-    public ResponseEntity<DataMsgResponseDto> createGameRoom(@RequestBody GameRoomRequestDto gameRoomRequestDto,
+    public ResponseEntity<DataMsgResponseDto> createGameRoom(@RequestBody @Valid GameRoomRequestDto gameRoomRequestDto,
                                                              HttpServletRequest request) {
         log.info(">>> 메인페이지 이동 - 방 이름 : {},", gameRoomRequestDto.getTitle());
         return ResponseEntity.ok(gameRoomService.createGameRoom(gameRoomRequestDto, request));

--- a/src/main/java/com/project/trysketch/dto/request/GameRoomRequestDto.java
+++ b/src/main/java/com/project/trysketch/dto/request/GameRoomRequestDto.java
@@ -3,6 +3,7 @@ package com.project.trysketch.dto.request;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import javax.validation.constraints.Pattern;
 
 // 1. 기능    : 게임 방 제목 입력 요소
 // 2. 작성자  : 김재영
@@ -10,5 +11,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class GameRoomRequestDto {
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣`~!@#$%^&*()_=+|{};:,.<>/?]{2,25}$", message = "방제목은 2자이상, 25자이하이어야하며 한글, 대소문자, 숫자, 특수문자만 가능합니다.")
     private String title;
 }

--- a/src/main/java/com/project/trysketch/global/exception/StatusMsgCode.java
+++ b/src/main/java/com/project/trysketch/global/exception/StatusMsgCode.java
@@ -15,7 +15,7 @@ public enum StatusMsgCode {
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     EXIST_USER(HttpStatus.BAD_REQUEST, "중복된 이메일입니다."),
     EXIST_NICK(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다."),
-    BAD_ID_PASSWORD(HttpStatus.BAD_REQUEST, "아이디나 비밀번호 패턴이 맞지 않습니다."),
+    BAD_ID_PASSWORD(HttpStatus.BAD_REQUEST, "형식이 맞지 않습니다."),
     INVALID_AUTH_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
 
 

--- a/src/main/java/com/project/trysketch/redis/dto/GuestNickRequestDto.java
+++ b/src/main/java/com/project/trysketch/redis/dto/GuestNickRequestDto.java
@@ -1,11 +1,15 @@
 package com.project.trysketch.redis.dto;
 
 import lombok.Getter;
+import javax.validation.constraints.Pattern;
 
 // 1. 기능   : 비회원 닉네임 요청값
 // 2. 작성자 : 서혁수
 @Getter
 public class GuestNickRequestDto {
+
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,12}$", message = "닉네임은 2자이상, 12자이하이어야하며 한글, 대소문자, 숫자만 가능합니다.")
     private String nickname;
+
     private String imgUrl;
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feature/73 -> develop

### 변경 사항
- 방제목 정규식 적용 (알파벳 대소문자, 한글, 숫자, 특수문자, 2~25자)
- 닉네임 정규식 적용 (알파벳 대소문자, 한글, 숫자, 2~12자)

### 테스트 결과
Postman 테스트 결과 이상 없습니다