### PR TITLE
[FEAT] SSE 이용한 실시간 게임방조회 로직 코드 (#68)

### DIFF
--- a/src/main/java/com/project/trysketch/global/dto/DataMsgResponseDto.java
+++ b/src/main/java/com/project/trysketch/global/dto/DataMsgResponseDto.java
@@ -3,7 +3,6 @@ package com.project.trysketch.global.dto;
 import com.project.trysketch.global.exception.StatusMsgCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 // 1. 기능   : 메시지와 데이터를 반환하는 dto
 // 2. 작성자 : 김재영
@@ -11,12 +10,12 @@ import org.springframework.http.HttpStatus;
 @NoArgsConstructor
 public class DataMsgResponseDto {
     private int statusCode;
-    private String statusMsg;
+    private String message;
     private Object data;
 
     public DataMsgResponseDto(StatusMsgCode statusMsgCode, Object data) {
         this.statusCode = statusMsgCode.getHttpStatus().value();
-        this.statusMsg = statusMsgCode.getDetail();
+        this.message = statusMsgCode.getDetail();
         this.data = data;
     }
 }

--- a/src/main/java/com/project/trysketch/global/dto/DataMsgResponseDto.java
+++ b/src/main/java/com/project/trysketch/global/dto/DataMsgResponseDto.java
@@ -10,12 +10,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 @NoArgsConstructor
 public class DataMsgResponseDto {
-    private HttpStatus httpStatus;
+    private int statusCode;
     private String statusMsg;
     private Object data;
 
     public DataMsgResponseDto(StatusMsgCode statusMsgCode, Object data) {
-        this.httpStatus = statusMsgCode.getHttpStatus();
+        this.statusCode = statusMsgCode.getHttpStatus().value();
         this.statusMsg = statusMsgCode.getDetail();
         this.data = data;
     }

--- a/src/main/java/com/project/trysketch/repository/GameRoomRepository.java
+++ b/src/main/java/com/project/trysketch/repository/GameRoomRepository.java
@@ -2,7 +2,6 @@ package com.project.trysketch.repository;
 
 import com.project.trysketch.entity.GameRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
 
 // 1. 기능   : 게임 방 repository

--- a/src/main/java/com/project/trysketch/sse/SseController.java
+++ b/src/main/java/com/project/trysketch/sse/SseController.java
@@ -1,0 +1,63 @@
+package com.project.trysketch.sse;
+
+import java.io.IOException;
+import com.project.trysketch.dto.request.GameRoomRequestDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@Slf4j
+public class SseController {
+    private final SseEmitters sseEmitters;
+
+    public SseController(SseEmitters sseEmitters) {
+        this.sseEmitters = sseEmitters;
+    }
+
+
+    // Emitter 생성 및 SSE 연결
+    @GetMapping(value = "/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<SseEmitter> connect() {
+
+        // Emitter 객체 생성. 1분으로 설정
+        SseEmitter emitter = new SseEmitter(60 * 1000L);
+        sseEmitters.add(emitter);
+
+        // SSE 연결 및 데이터 전송
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("connect")               // 이벤트의 이름
+                    .data("connected!"));              // 만료시간 전 데이터 받을수 있도록 SSE 연결시 데이터 전달
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return ResponseEntity.ok(emitter);
+    }
+
+
+
+    // 게임 방 생성 (생성한 게임방에 대해서만 SSE 커넥션이 열려있는 모든 클라이언트에게 전달)
+    @PostMapping("/create/room")
+    public ResponseEntity<Void> createGameRoom(@RequestBody GameRoomRequestDto gameRoomRequestDto,
+                                                             HttpServletRequest request) {
+        log.info(">>> 메인페이지 이동 - 방 이름 : {},", gameRoomRequestDto.getTitle());
+        sseEmitters.createRoom(gameRoomRequestDto, request);
+        return ResponseEntity.ok().build();
+    }
+
+
+//    // 게임 방 생성 (생성된 게임방 포함 모든 게임방 정보 SSE 커넥션이 열려있는 모든 클라이언트에게 전달)
+//    @PostMapping("/create/room")
+//    public ResponseEntity<Void> createGameRoom(@RequestBody GameRoomRequestDto gameRoomRequestDto,
+//                                               HttpServletRequest request,@PageableDefault(size = 10, sort = "createdAt" , direction = Sort.Direction.DESC) Pageable pageable) {
+//        log.info(">>> 메인페이지 이동 - 방 이름 : {},", gameRoomRequestDto.getTitle());
+//        sseEmitters.createRoom(gameRoomRequestDto, request, pageable);
+//        return ResponseEntity.ok().build();
+//    }
+
+}

--- a/src/main/java/com/project/trysketch/sse/SseEmitters.java
+++ b/src/main/java/com/project/trysketch/sse/SseEmitters.java
@@ -1,24 +1,20 @@
 package com.project.trysketch.sse;
 
-import com.project.trysketch.dto.request.GameRoomRequestDto;
-import com.project.trysketch.service.GameRoomService;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+
+// 1. 기능   : SSE 연결시 발생시킬 event 생성로직
+// 2. 작성자 : 황미경
 
 @Component
 @Slf4j
 public class SseEmitters {
 
     private final List<SseEmitter> emitters = new CopyOnWriteArrayList<>();
-
-    @Autowired
-    private GameRoomService gameRoomService;
 
 
     // SSE emitter 등록 메서드
@@ -46,32 +42,17 @@ public class SseEmitters {
     }
 
 
-    // 게임 방 생성 (생성한 게임방에 대해서만 SSE 커넥션이 열려있는 모든 클라이언트에게 전달)
-    public void createRoom(GameRoomRequestDto gameRoomRequestDto, HttpServletRequest request) {
+    // 게임 방 생성, 소멸시 SSE 커넥션 연결된 모든 클라이언트에 방리스트 전달
+    public void changeRoom(Object roomInfo) {
         emitters.forEach(emitter -> {
+
             try {
                 emitter.send(SseEmitter.event()
-                        .name("createRoom")
-                        .data(gameRoomService.createGameRoom(gameRoomRequestDto, request)));
+                        .name("changeRoom")     // event의 이름 지정
+                        .data(roomInfo));                  // event에 담을 data
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
         });
     }
-
-
-//    // 게임 방 생성 (생성된 게임방 포함 모든 게임방 정보 SSE 커넥션이 열려있는 모든 클라이언트에게 전달)
-//    public void createRoom(GameRoomRequestDto gameRoomRequestDto, HttpServletRequest request, Pageable pageable) {
-//        emitters.forEach(emitter -> {
-//            gameRoomService.createGameRoom(gameRoomRequestDto, request);
-//            try {
-//                emitter.send(SseEmitter.event()
-//                        .name("createRoom")
-//                        .data(gameRoomService.getAllGameRoom(pageable)));
-//            } catch (IOException e) {
-//                throw new RuntimeException(e);
-//            }
-//        });
-//    }
-
 }

--- a/src/main/java/com/project/trysketch/sse/SseEmitters.java
+++ b/src/main/java/com/project/trysketch/sse/SseEmitters.java
@@ -1,0 +1,77 @@
+package com.project.trysketch.sse;
+
+import com.project.trysketch.dto.request.GameRoomRequestDto;
+import com.project.trysketch.service.GameRoomService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Component
+@Slf4j
+public class SseEmitters {
+
+    private final List<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+
+    @Autowired
+    private GameRoomService gameRoomService;
+
+
+    // SSE emitter 등록 메서드
+    SseEmitter add(SseEmitter emitter) {
+        this.emitters.add(emitter);
+        log.info("new emitter added: {}", emitter);
+        log.info("emitter list size: {}", emitters.size());
+        log.info("emitter list: {}", emitters);
+
+        // 비동기요청 완료시 콜백 등록
+        emitter.onCompletion(() -> {
+            log.info("onCompletion callback");
+
+            // 타임아웃 발생시 브라우저에 재요청 연결 보내는데, 이때 새로운 객체 다시 생성하므로 기존의 Emitter객체 리스트에서 삭제
+            this.emitters.remove(emitter);
+        });
+
+        // 타임아웃 발생시 콜백 등록
+        emitter.onTimeout(() -> {
+            log.info("onTimeout callback");
+            emitter.complete();
+        });
+
+        return emitter;
+    }
+
+
+    // 게임 방 생성 (생성한 게임방에 대해서만 SSE 커넥션이 열려있는 모든 클라이언트에게 전달)
+    public void createRoom(GameRoomRequestDto gameRoomRequestDto, HttpServletRequest request) {
+        emitters.forEach(emitter -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("createRoom")
+                        .data(gameRoomService.createGameRoom(gameRoomRequestDto, request)));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+
+//    // 게임 방 생성 (생성된 게임방 포함 모든 게임방 정보 SSE 커넥션이 열려있는 모든 클라이언트에게 전달)
+//    public void createRoom(GameRoomRequestDto gameRoomRequestDto, HttpServletRequest request, Pageable pageable) {
+//        emitters.forEach(emitter -> {
+//            gameRoomService.createGameRoom(gameRoomRequestDto, request);
+//            try {
+//                emitter.send(SseEmitter.event()
+//                        .name("createRoom")
+//                        .data(gameRoomService.getAllGameRoom(pageable)));
+//            } catch (IOException e) {
+//                throw new RuntimeException(e);
+//            }
+//        });
+//    }
+
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [x] 코드 리팩토링

### 반영 브랜치
feature/68 -> develop

### 변경 사항
- SSE 통신하여 실시간으로 변동하는 게임방조회 기능 구현
- DataMsgResponseDto의 필드값 HttpStatus -> int statusCode로 변경

### 테스트 결과
프론트와 확인 완료했습니다.