### PR TITLE
[REFACTOR] 비회원 랜덤 프로필 이미지 순서, 게임 방 나가기 API uri 수정 (#62)

### DIFF
--- a/src/main/java/com/project/trysketch/controller/GameRoomController.java
+++ b/src/main/java/com/project/trysketch/controller/GameRoomController.java
@@ -48,7 +48,7 @@ public class GameRoomController {
     }
 
     // 게임 방 나가기
-    @DeleteMapping("/room/{id}/exit")
+    @DeleteMapping("/room/exit/{id}")
     public ResponseEntity<MsgResponseDto> exitGameRoom(@PathVariable Long id,
                                                        HttpServletRequest request) {
         log.info(">>> 방 퇴장 - 방 id : {}, 유저 id : {}", id, request);

--- a/src/main/java/com/project/trysketch/service/UserService.java
+++ b/src/main/java/com/project/trysketch/service/UserService.java
@@ -42,6 +42,7 @@ public class UserService {
     private final GuestRepository guestRepository;
     private final ThumbImgRepository thumbImgRepository;
     private static int IMG_MAXIMUM = 3;
+    private static int IMG_NUM = 0;
 
 
     // 회원가입
@@ -158,8 +159,8 @@ public class UserService {
 
     // 랜덤 이미지 불러오기
     public String getRandomThumbImg() {
-        int randomNum = (int) (Math.random() * IMG_MAXIMUM + 1);
-        ThumbImg thumbImg = thumbImgRepository.findById(randomNum).orElseThrow(
+        IMG_NUM = (IMG_NUM == IMG_MAXIMUM) ? 1 : IMG_NUM + 1;
+        ThumbImg thumbImg = thumbImgRepository.findById(IMG_NUM).orElseThrow(
                 () -> new CustomException(StatusMsgCode.IMAGE_NOT_FOUND)
         );
         return thumbImg.getImgUrl();


### PR DESCRIPTION
### PR 타입
- [x] 코드 리팩토링

### 반영 브랜치
feature/62-> develop

### 변경 사항
- 비회원 랜덤 프로필 이미지 순서대로 나오도록 로직 수정
- 추후 이미지 개수가 바뀌었을 경우, IMG_MAXIMUM만 변경해주시면 됩니다.
- 게임 방 나가기 API uri 가 변경되었습니다.
    - 기존 : /api/room/{id}/exit
    - 변경 : /api/room/exit/{id}

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
api 관련해서는 프론트엔드 분들께 전달 드렸습니다.
