### PR TITLE
유저 활동내역 저장기능 구현, 업적 기능 구현

### DIFF
--- a/src/main/java/com/project/trysketch/service/KakaoService.java
+++ b/src/main/java/com/project/trysketch/service/KakaoService.java
@@ -128,16 +128,14 @@ public class KakaoService {
     private User registerKakaoUserIfNeeded(OAuthRequestDto kakaoUserInfo) {
         // DB 에 중복된 Kakao Id 가 있는지 확인
         Long kakaoId = kakaoUserInfo.getId();
-        User kakaoUser = userRepository.findByKakaoId(kakaoId).orElseThrow(
-                () -> new CustomException(StatusMsgCode.USER_NOT_FOUND)
-        );
+        log.info(">>>>>>>>>>>>> [kakaoService] - 레지스트 부분 kakaoUser 시작");
+        User kakaoUser = userRepository.findByKakaoId(kakaoId).orElse(null);
+        log.info(">>>>>>>>>>>>> [kakaoService] - 레지스트 부분 kakaoUser 완료");
         if (kakaoUser == null) {
             // 카카오 사용자 email 동일한 email 가진 회원이 있는지 확인
             String kakaoEmail = kakaoUserInfo.getEmail();
 
-            User sameEmailUser = userRepository.findByEmail(kakaoEmail).orElseThrow(
-                    () -> new CustomException(StatusMsgCode.USER_NOT_FOUND)
-            );
+            User sameEmailUser = userRepository.findByEmail(kakaoEmail).orElse(null);
 
             if (sameEmailUser != null) {
                 kakaoUser = sameEmailUser;

--- a/src/main/java/com/project/trysketch/service/KakaoService.java
+++ b/src/main/java/com/project/trysketch/service/KakaoService.java
@@ -52,6 +52,11 @@ public class KakaoService {
         // 3. 필요시에 회원가입
         User kakaoUser = registerKakaoUserIfNeeded(kakaoUserInfo);
 
+        History history = kakaoUser.getHistory().updateVisits(1L);
+        historyRepository.save(history);
+
+        historyService.getTrophyOfVisit(kakaoUser);
+
         // 4. JWT 토큰 반환
         String createToken =  jwtUtil.createToken(kakaoUser.getEmail(), kakaoUser.getNickname());
         response.addHeader(JwtUtil.AUTHORIZATION_HEADER, createToken);
@@ -138,12 +143,8 @@ public class KakaoService {
                 kakaoUser = sameEmailUser;
                 // 기존 회원정보에 카카오 Id 추가
                 kakaoUser = kakaoUser.kakaoIdUpdate(kakaoId);
+
                 userRepository.save(kakaoUser);
-
-                // 방문 횟수 1 증가!
-                History history = kakaoUser.getHistory().updateVisits(1L);
-
-                historyRepository.save(history);
             } else {
                 // history 생성부
                 History newHistory = historyService.createHistory();
@@ -159,12 +160,8 @@ public class KakaoService {
                         .email(email)
                         .imgUrl(userService.getRandomThumbImg().getMessage())
                         .build();
-                userRepository.save(kakaoUser);
-                newHistory.updateUser(kakaoUser);
-
-                // 방문 횟수 1 증가!
-                History history = kakaoUser.getHistory().updateVisits(1L);
-                historyRepository.save(history);
+                User newUser = userRepository.save(kakaoUser);
+                newHistory.updateUser(newUser);
             }
 
         }

--- a/src/main/java/com/project/trysketch/service/NaverService.java
+++ b/src/main/java/com/project/trysketch/service/NaverService.java
@@ -68,12 +68,12 @@ public class NaverService {
         // 2. 토큰으로 Naver API 호출 : "액세스 토큰"으로 "Naver 사용자 정보" 가져오기
         NaverRequestDto naverUserInfo = getNaverUserInfo(accessToken, randomNickname);
 
+        // 3. 필요시에 회원가입
         User naverUser = registerNaverUserIfNeeded(naverUserInfo);
 
         History history = naverUser.getHistory().updateVisits(1L);
-        historyRepository.saveAndFlush(history);
+        historyRepository.save(history);
 
-        log.info(">>>>>>>>>>>>>>>>>> naver History의 주인 : {}",history.getUser().getId());
         historyService.getTrophyOfVisit(naverUser);
 
         String createToken = jwtUtil.createToken(naverUser.getEmail(), naverUser.getNickname());
@@ -150,7 +150,7 @@ public class NaverService {
                 // 기존 회원정보에 NaverId 추가
                 naverUser = naverUser.naverIdUpdate(naverId);
 
-                naverUser = userRepository.saveAndFlush(naverUser);
+                naverUser = userRepository.save(naverUser);
             } else {
                 // history 생성부
                 History newHistory = historyService.createHistory();
@@ -167,10 +167,7 @@ public class NaverService {
                         .imgUrl(userService.getRandomThumbImg().getMessage())
                         .history(newHistory)
                         .build();
-                User user2 = userRepository.saveAndFlush(naverUser);
-                User newUser = userRepository.findById(user2.getId()).orElseThrow(
-                        () -> new CustomException(StatusMsgCode.USER_NOT_FOUND)
-                );
+                User newUser = userRepository.save(naverUser);
                 newHistory.updateUser(newUser);
             }
         }


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
feature/117-> develop

### 변경 사항
- 카카오 네이버 구글 소셜로그인시 유저 활동이력 저장기능 구현
- 로그인시 방문횟수 +1 기능 추가
- 방문횟수가 추가될 때마다 업적이 완수가 되었는지 검증 메소드 실행 후 달성시 해당 업적 부여

### 테스트 결과
서버 배포 테스트 결과 이상 없습니다.
