### PR TITLE
[REFACTOR] 비회원 토큰 만료시간 10시간으로 복귀 (#5)

### DIFF
--- a/src/main/java/com/project/trysketch/dto/CacheKey.java
+++ b/src/main/java/com/project/trysketch/dto/CacheKey.java
@@ -3,7 +3,7 @@ package com.project.trysketch.dto;
 public class CacheKey {
     private CacheKey() {
     }
-    public static final int DEFAULT_EXPIRE_SEC = 7200;
+    public static final int DEFAULT_EXPIRE_SEC = 18000;
     public static final String USER = "user";
-    public static final int USER_EXPIRE_SEC = 7200;
+    public static final int USER_EXPIRE_SEC = 18000;
 }

--- a/src/main/java/com/project/trysketch/entity/Guest.java
+++ b/src/main/java/com/project/trysketch/entity/Guest.java
@@ -10,7 +10,7 @@ import java.io.Serializable;
 // 1. 기능   : 비회원 구성요소
 // 2. 작성자 : 서혁수
 @Getter
-@RedisHash(value = "guest", timeToLive = 18000L)
+@RedisHash(value = "guest", timeToLive = 36000L)
 public class Guest implements Serializable {
     // RedisHash : Hash Collection 명시
     // Jpa 의 Entity 에 해당하는 어노테이션 즉, value 는 Key 를 만들 때 사용하는 것으로


### PR DESCRIPTION
### PR 타입
- [x] 코드 리팩토링

### 반영 브랜치
feature/5 -> develop

### 변경 사항
- 백 서버가 내려가면 레디스에 키 값이 삭제될 때 참조하는 값들이 같이 삭제가 되지 않는것으로 확인
- 코드자체는 문제가 없기에 다시 원래 만료시간인 10시간으로 재설정 하였습니다.