### PR TITLE
[FIX] 소셜(naver, kakao, google) 로그인시 history NullPointerException 에러 해결

### DIFF
--- a/src/main/java/com/project/trysketch/entity/History.java
+++ b/src/main/java/com/project/trysketch/entity/History.java
@@ -33,9 +33,7 @@ public class History extends Timestamped {
     private Long visits;
 
     // 1:1 연관관계 - User
-//    @OneToOne(mappedBy = "history")
     @OneToOne
-    @JoinColumn(name = "user_id")
     private User user;
 
     public void updatePlaytime(Long plusnum) {

--- a/src/main/java/com/project/trysketch/entity/User.java
+++ b/src/main/java/com/project/trysketch/entity/User.java
@@ -37,8 +37,7 @@ public class User {
     @Column(nullable = false)
     private String imgUrl;
 
-    @JoinColumn(name = "history_id")
-    @OneToOne
+    @OneToOne(mappedBy = "user")
     private History history;
 
 //    public User(String email, String nickname, String password) {

--- a/src/main/java/com/project/trysketch/service/KakaoService.java
+++ b/src/main/java/com/project/trysketch/service/KakaoService.java
@@ -134,7 +134,6 @@ public class KakaoService {
         if (kakaoUser == null) {
             // 카카오 사용자 email 동일한 email 가진 회원이 있는지 확인
             String kakaoEmail = kakaoUserInfo.getEmail();
-
             User sameEmailUser = userRepository.findByEmail(kakaoEmail).orElse(null);
 
             if (sameEmailUser != null) {
@@ -149,19 +148,18 @@ public class KakaoService {
                 // 신규 회원가입
                 String password = UUID.randomUUID().toString();
                 String encodedPassword = passwordEncoder.encode(password);
-                String email = kakaoUserInfo.getEmail();
 
                 kakaoUser = User.builder()
                         .password(encodedPassword)
                         .kakaoId(kakaoId)
                         .nickname(kakaoUserInfo.getNickname())
-                        .email(email)
+                        .email(kakaoUserInfo.getEmail())
                         .imgUrl(userService.getRandomThumbImg().getMessage())
+                        .history(newHistory)
                         .build();
                 User newUser = userRepository.save(kakaoUser);
                 newHistory.updateUser(newUser);
             }
-
         }
         return kakaoUser;
     }

--- a/src/main/java/com/project/trysketch/service/NaverService.java
+++ b/src/main/java/com/project/trysketch/service/NaverService.java
@@ -157,13 +157,12 @@ public class NaverService {
                 // 신규 회원가입
                 String password = UUID.randomUUID().toString();
                 String encodedPassword = passwordEncoder.encode(password);
-                String email = naverUserInfo.getEmail();
 
                 naverUser = User.builder()
                         .password(encodedPassword)
                         .naverId(naverId)
                         .nickname(naverUserInfo.getNickname())
-                        .email(email)
+                        .email(naverUserInfo.getEmail())
                         .imgUrl(userService.getRandomThumbImg().getMessage())
                         .history(newHistory)
                         .build();


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
feature/146 -> develop

### 변경 사항
- 소셜로그인 통해 회원가입시 history 저장되지 않아, read시 NullPointerException 터지는 에러 
- OneToOne 연관관계 변경함으로써 해결

### 테스트 결과
서버 확인 결과 이상 없습니다