### PR TITLE
[FIX] 게임 중 유저 나갈 시 게임 종료되어도 gameFlow 안 지워지는 에러해결 (#149)

### DIFF
--- a/src/main/java/com/project/trysketch/entity/GameFlow.java
+++ b/src/main/java/com/project/trysketch/entity/GameFlow.java
@@ -46,8 +46,8 @@ public class GameFlow {
     @Column(nullable = false)
     private boolean isSubmitted;
 
-    @ManyToOne
-    private GameRoomUser gameRoomUser;
+    @Column(nullable = false)
+    private String userImgPath;
 
     public void update(boolean isSubmitted) {
         this.isSubmitted = isSubmitted;

--- a/src/main/java/com/project/trysketch/entity/GameRoomUser.java
+++ b/src/main/java/com/project/trysketch/entity/GameRoomUser.java
@@ -40,11 +40,7 @@ public class GameRoomUser {
 
     @Column
     private String imgUrl;
-
-    @OneToMany(mappedBy = "gameRoomUser")
-    @Builder.Default
-    private List<GameFlow> gameFlowList = new ArrayList<>();
-
+    
     public void update(boolean readyStatus) {
         this.readyStatus = readyStatus;
     }

--- a/src/main/java/com/project/trysketch/service/GameRoomService.java
+++ b/src/main/java/com/project/trysketch/service/GameRoomService.java
@@ -241,8 +241,8 @@ public class GameRoomService {
         } else {
             GameRoom currentGameRoom = gameRoomUser.getGameRoom();
 
-            // 게임이 진행중이며, 나가는 유저 포함 4명 이하일 때 게임종료 (4명 미만으로는 게임진행 불가)
-            if(currentGameRoom.isPlaying() && currentGameRoom.getGameRoomUserList().size() <= 2) {
+            // 게임이 진행중이며, 나가는 유저 포함 3명 이하일 때 게임종료 (3명 미만으로는 게임진행 불가)
+            if(currentGameRoom.isPlaying() && currentGameRoom.getGameRoomUserList().size() <= 3) {
                 gameService.shutDownGame(gameRoomId);
             }
 

--- a/src/main/java/com/project/trysketch/service/GameService.java
+++ b/src/main/java/com/project/trysketch/service/GameService.java
@@ -298,7 +298,7 @@ public class GameService {
                         .keyword(requestDto.getKeyword())
                         .nickname(gamerInfo.get(GamerEnum.NICK.key()))
                         .webSessionId(requestDto.getWebSessionId())
-                        .gameRoomUser(gameRoomUser)
+                        .userImgPath(gameRoomUser.getImgUrl())
                         .isSubmitted(!requestDto.isSubmitted()).build();
                 log.info(">>>>>>> [GameService - getToggleSubmit] 처음으로 제출하는 유저의 키워드 : {}", gameFlow.getKeyword());
             }
@@ -312,7 +312,7 @@ public class GameService {
                         .imagePath(saveImage(requestDto))
                         .nickname(gamerInfo.get(GamerEnum.NICK.key()))
                         .webSessionId(requestDto.getWebSessionId())
-                        .gameRoomUser(gameRoomUser)
+                        .userImgPath(gameRoomUser.getImgUrl())
                         .isSubmitted(!requestDto.isSubmitted()).build();
                 log.info(">>>>>>> [GameService - getToggleSubmit] 처음으로 제출하는 유저의 이미지 : {}", gameFlow.getImagePath());
             }
@@ -651,7 +651,7 @@ public class GameService {
                     gameResult.add(gameFlow.getKeyword());
                 }
                 // 2차원 배열의 요소에 프로필사진 url 저장
-                gameResult.add(gameFlow.getGameRoomUser().getImgUrl());
+                gameResult.add(gameFlow.getUserImgPath());
                 // 닉네임, 키워드 or imagePath, 프로필사진 담긴 리스트를 2차원 배열의 요소로 저장
                 resultList[i - 1][j - 1] = gameResult;
             }
@@ -757,6 +757,7 @@ public class GameService {
                             .nickname(gameRoomUser.getNickname())
                             .webSessionId(userUUID)
                             .imagePath("미제출")
+                            .userImgPath(gameRoomUser.getImgUrl())
                             .isSubmitted(true).build();
                     gameFlowRepository.saveAndFlush(gameFlow);
                 } else {
@@ -768,6 +769,7 @@ public class GameService {
                             .nickname(gameRoomUser.getNickname())
                             .webSessionId(userUUID)
                             .keyword("미제출")
+                            .userImgPath(gameRoomUser.getImgUrl())
                             .isSubmitted(true).build();
                     gameFlowRepository.saveAndFlush(gameFlow);
                 }


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
feature/149 -> develop

### 변경 사항
- gameRoomUser와 GameFlow 연관관계 맺은 문제로 인해 새로운 문제 발생하여 연관관계 없앰으로 오류 해결
- 기존의 gameRoomUser와 GameFlow 연관관계 없애고, gameFlow 저장되는 시점에 유저의 프로필 imagePath 받아 저장하도록 수정

### 테스트 결과
서버 배포 후 확인결과 이상 없습니다