### PR TITLE
[FIX] 오류 발생한 gameRoom 나와서 다른방 입장 시도시 입장 안 되는 에러 해결 (151)

### DIFF
--- a/src/main/java/com/project/trysketch/repository/GameRoomUserRepository.java
+++ b/src/main/java/com/project/trysketch/repository/GameRoomUserRepository.java
@@ -35,4 +35,6 @@ public interface GameRoomUserRepository extends JpaRepository<GameRoomUser, Long
     Long countByUserId(Long valueOf);
 
     Long countByGameRoomId(Long roomId);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/project/trysketch/service/GameService.java
+++ b/src/main/java/com/project/trysketch/service/GameService.java
@@ -531,9 +531,6 @@ public class GameService {
             throw new CustomException(StatusMsgCode.GAME_NOT_ONLINE);
         }
 
-        // 현재 GameRoom 의 UserList 가져오기
-        List<GameRoomUser> gameRoomUserList = gameRoomUserRepository.findAllByGameRoomId(requestDto.getRoomId());
-
         // gameRoom 정보 가져오기
         GameRoom gameRoom = gameRoomRepository.findById(requestDto.getRoomId()).orElseThrow(
                 () -> new CustomException(StatusMsgCode.GAMEROOM_NOT_FOUND)


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
feature/151 -> develop

### 변경 사항
- 오류로 인해 gameRoomUser, gameRoom 남아있는 상황에서 로비 페이지 이동 후 다른 방 입장 시도시 에러 발생
- 기존의 gameRoomUser 삭제하여 새로운 방으로 들어갈 수 있도록 해결

### 테스트 결과
서버확인 결과 이상 없습니다