### PR TITLE
[FIX] 닉네임 수정시 정규식 적용 (#166)

### DIFF
--- a/src/main/java/com/project/trysketch/controller/ImageController.java
+++ b/src/main/java/com/project/trysketch/controller/ImageController.java
@@ -1,20 +1,11 @@
 package com.project.trysketch.controller;
 
-import com.project.trysketch.dto.request.UserRequestDto;
-import com.project.trysketch.entity.ImageLike;
 import com.project.trysketch.global.dto.DataMsgResponseDto;
-import com.project.trysketch.global.dto.MsgResponseDto;
 import com.project.trysketch.service.ImageService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
 import javax.servlet.http.HttpServletRequest;
-import java.util.List;
 
 
 // 1. 기능   : ImageLike 컨트롤러
@@ -52,25 +43,6 @@ public class ImageController {
     public ResponseEntity<DataMsgResponseDto> imageLike(@PathVariable Long imageId,
                                                         HttpServletRequest request) {
         return ResponseEntity.ok(imageService.likeImage(imageId, request));
-    }
-
-//======================================================================================================
-    // 마이페이지에서 좋아요 누른 사진 조회
-    @GetMapping("/mypage/image-like") // 수정 추가 김재영 01.29
-    public ResponseEntity<Page<ImageLike>> getImage(@PageableDefault(size = 5,sort = "createdAt",direction = Sort.Direction.DESC) Pageable pageable,
-                                                    HttpServletRequest request) {
-        return ResponseEntity.ok(imageService.getImage(request, pageable));
-    }
-    // 마이페이지 회원조회
-    @GetMapping("/mypage")
-    public ResponseEntity<DataMsgResponseDto> getMyPage(HttpServletRequest request) {
-        return ResponseEntity.ok(imageService.getMyPage(request));
-    }
-
-    // 마이페이지 정보변경
-    @PatchMapping("/mypage/profile")
-    public ResponseEntity<DataMsgResponseDto> patchMyPage(@RequestBody UserRequestDto userRequestDto, HttpServletRequest request) {
-        return ResponseEntity.ok(imageService.patchMyPage(userRequestDto, request));
     }
 
 

--- a/src/main/java/com/project/trysketch/controller/MypageController.java
+++ b/src/main/java/com/project/trysketch/controller/MypageController.java
@@ -1,0 +1,45 @@
+package com.project.trysketch.controller;
+
+import com.project.trysketch.dto.request.UserRequestDto;
+import com.project.trysketch.entity.ImageLike;
+import com.project.trysketch.global.dto.DataMsgResponseDto;
+import com.project.trysketch.service.ImageService;
+import com.project.trysketch.service.MypageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/mypage")
+public class MypageController {
+
+    private final ImageService imageService;
+    private final MypageService mypageService;
+
+    // 마이페이지에서 좋아요 누른 사진 조회
+    @GetMapping("/image-like") // 수정 추가 김재영 01.29
+    public ResponseEntity<Page<ImageLike>> getImage(@PageableDefault(size = 5,sort = "createdAt",direction = Sort.Direction.DESC) Pageable pageable,
+                                                    HttpServletRequest request) {
+        return ResponseEntity.ok(imageService.getImage(request, pageable));
+    }
+    // 마이페이지 회원조회
+    @GetMapping
+    public ResponseEntity<DataMsgResponseDto> getMyPage(HttpServletRequest request) {
+        return ResponseEntity.ok(mypageService.getMyPage(request));
+    }
+
+    // 마이페이지 정보변경
+    @PatchMapping("/profile")
+    public ResponseEntity<DataMsgResponseDto> patchMyPage(@RequestBody @Valid UserRequestDto userRequestDto, HttpServletRequest request) {
+        return ResponseEntity.ok(mypageService.patchMyPage(userRequestDto, request));
+    }
+
+}

--- a/src/main/java/com/project/trysketch/dto/request/UserRequestDto.java
+++ b/src/main/java/com/project/trysketch/dto/request/UserRequestDto.java
@@ -3,13 +3,16 @@ package com.project.trysketch.dto.request;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import javax.validation.constraints.Pattern;
 
 @Getter
 @AllArgsConstructor
 @Builder
 public class UserRequestDto {
 
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣 ]{2,12}$", message = "닉네임은 2자이상, 12자이하이어야하며 한글, 대소문자, 숫자, 띄어쓰기만 가능합니다.")
     private String nickname;
+
     private String imgUrl;
 
 }

--- a/src/main/java/com/project/trysketch/service/ImageService.java
+++ b/src/main/java/com/project/trysketch/service/ImageService.java
@@ -1,8 +1,6 @@
 package com.project.trysketch.service;
 
-import com.project.trysketch.dto.request.UserRequestDto;
 import com.project.trysketch.dto.response.ImageLikeResponseDto;
-import com.project.trysketch.dto.response.UserResponseDto;
 import com.project.trysketch.global.dto.DataMsgResponseDto;
 import com.project.trysketch.global.dto.MsgResponseDto;
 import com.project.trysketch.global.exception.CustomException;
@@ -21,7 +19,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import javax.servlet.http.HttpServletRequest;
 import java.util.*;
 
@@ -179,46 +176,5 @@ public class ImageService {
         return new MsgResponseDto(StatusMsgCode.DELETE_IMAGE);
     }
 
-    // 마이페이지 회원조회
-    public DataMsgResponseDto getMyPage(HttpServletRequest request) {
 
-        // 유저 정보 가져오기
-        Claims claims = jwtUtil.authorizeToken(request);
-        User user = userRepository.findByEmail(claims.get("email").toString()).orElseThrow(
-                () -> new CustomException(StatusMsgCode.USER_NOT_FOUND)
-        );
-
-        // 유저 정보에서 필요한 정보( id, email, nickname, ImgUrl ) 추출
-        UserResponseDto userResponseDto = UserResponseDto.builder()
-                .id(user.getId())
-                .email(user.getEmail())
-                .nickname(user.getNickname())
-                .imagePath(user.getImgUrl())
-                .build();
-
-        return new DataMsgResponseDto(StatusMsgCode.OK,userResponseDto);
-    }
-
-    // 마이페이지 회원 닉네임, 프로필사진 수정
-    @Transactional
-    public DataMsgResponseDto patchMyPage(UserRequestDto userRequestDto, HttpServletRequest request) {
-
-        // 유저 정보 가져오기
-        Claims claims = jwtUtil.authorizeToken(request);
-        User user = userRepository.findByEmail(claims.get("email").toString()).orElseThrow(
-                () -> new CustomException(StatusMsgCode.USER_NOT_FOUND)
-        );
-
-        // 유저 프로필, 닉네임 변경
-        user.update(userRequestDto.getNickname(), userRequestDto.getImgUrl());
-
-        // 유저 정보에서 필요한 정보( id, email, nickname, ImgUrl ) 추출
-        UserResponseDto userResponseDto = UserResponseDto.builder()
-                .id(user.getId())
-                .nickname(user.getNickname())
-                .imagePath(user.getImgUrl())
-                .build();
-
-        return new DataMsgResponseDto(StatusMsgCode.UPDATE_USER_PROFILE, userResponseDto);
-    }
 }

--- a/src/main/java/com/project/trysketch/service/MypageService.java
+++ b/src/main/java/com/project/trysketch/service/MypageService.java
@@ -1,0 +1,69 @@
+package com.project.trysketch.service;
+
+import com.project.trysketch.dto.request.UserRequestDto;
+import com.project.trysketch.dto.response.UserResponseDto;
+import com.project.trysketch.entity.User;
+import com.project.trysketch.global.dto.DataMsgResponseDto;
+import com.project.trysketch.global.exception.CustomException;
+import com.project.trysketch.global.exception.StatusMsgCode;
+import com.project.trysketch.global.jwt.JwtUtil;
+import com.project.trysketch.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import javax.servlet.http.HttpServletRequest;
+
+
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MypageService {
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    // 마이페이지 회원조회
+    public DataMsgResponseDto getMyPage(HttpServletRequest request) {
+
+        // 유저 정보 가져오기
+        Claims claims = jwtUtil.authorizeToken(request);
+        User user = userRepository.findByEmail(claims.get("email").toString()).orElseThrow(
+                () -> new CustomException(StatusMsgCode.USER_NOT_FOUND)
+        );
+
+        // 유저 정보에서 필요한 정보( id, email, nickname, ImgUrl ) 추출
+        UserResponseDto userResponseDto = UserResponseDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .imagePath(user.getImgUrl())
+                .build();
+
+        return new DataMsgResponseDto(StatusMsgCode.OK,userResponseDto);
+    }
+
+    // 마이페이지 회원 닉네임, 프로필사진 수정
+    @Transactional
+    public DataMsgResponseDto patchMyPage(UserRequestDto userRequestDto, HttpServletRequest request) {
+
+        // 유저 정보 가져오기
+        Claims claims = jwtUtil.authorizeToken(request);
+        User user = userRepository.findByEmail(claims.get("email").toString()).orElseThrow(
+                () -> new CustomException(StatusMsgCode.USER_NOT_FOUND)
+        );
+
+        // 유저 프로필, 닉네임 변경
+        user.update(userRequestDto.getNickname(), userRequestDto.getImgUrl());
+
+        // 유저 정보에서 필요한 정보( id, email, nickname, ImgUrl ) 추출
+        UserResponseDto userResponseDto = UserResponseDto.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .imagePath(user.getImgUrl())
+                .build();
+
+        return new DataMsgResponseDto(StatusMsgCode.UPDATE_USER_PROFILE, userResponseDto);
+    }
+}


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
feature/166 -> develop

### 변경 사항
- 회원가입시 적용되는 정규식과 동일하게 닉네임 수정시에도 적용
- 마이페이지 관련 코드는 Mypage Controller와 Service 파일로 이동

### 테스트 결과
서버배포 확인 결과 이상 없습니다
