### PR TITLE
[FEAT] 유저 활동내역 기반 업적 관련 기능 완성 (#117)

### DIFF
--- a/src/main/java/com/project/trysketch/entity/GameRoomUser.java
+++ b/src/main/java/com/project/trysketch/entity/GameRoomUser.java
@@ -40,6 +40,9 @@ public class GameRoomUser {
 
     @Column
     private String imgUrl;
+
+    @OneToOne(mappedBy = "gameRoomUser")
+    private UserPlayTime userPlayTime;
     
     public void update(boolean readyStatus) {
         this.readyStatus = readyStatus;
@@ -50,16 +53,4 @@ public class GameRoomUser {
         this.webSessionId = userUUID;
     }
 
-    @Override
-    public String toString() {
-        return "GameRoomUser{" +
-                "id=" + id +
-                ", gameRoom=" + gameRoom +
-                ", userId=" + userId +
-                ", nickname='" + nickname + '\'' +
-                ", webSessionId='" + webSessionId + '\'' +
-                ", readyStatus=" + readyStatus +
-                ", imgUrl='" + imgUrl + '\'' +
-                '}';
-    }
 }

--- a/src/main/java/com/project/trysketch/entity/History.java
+++ b/src/main/java/com/project/trysketch/entity/History.java
@@ -13,7 +13,6 @@ import javax.persistence.*;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@ToString
 public class History extends Timestamped {
 
     @Id
@@ -36,12 +35,14 @@ public class History extends Timestamped {
     @OneToOne
     private User user;
 
-    public void updatePlaytime(Long plusnum) {
-        this.playtime += plusnum;
+    public History updatePlaytime(Long playtime) {
+        this.playtime += playtime;
+        return this;
     }
 
-    public void updateTrials(Long trials) {
+    public History updateTrials(Long trials) {
         this.trials += trials;
+        return this;
     }
 
     public History updateVisits(Long visits) {

--- a/src/main/java/com/project/trysketch/entity/User.java
+++ b/src/main/java/com/project/trysketch/entity/User.java
@@ -22,7 +22,6 @@ public class User {
     @Column(nullable = false, unique = true)
     private String email;
 
-//    @Column(nullable = false, unique = true)
     @Column(nullable = false)
     private String nickname;
 

--- a/src/main/java/com/project/trysketch/entity/UserPlayTime.java
+++ b/src/main/java/com/project/trysketch/entity/UserPlayTime.java
@@ -1,0 +1,37 @@
+package com.project.trysketch.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserPlayTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private LocalDateTime playStartTime;
+
+    @Column
+    private LocalDateTime playEndTime;
+
+    @Column
+    private Long gameRoomId;
+
+    @OneToOne
+    private GameRoomUser gameRoomUser;
+
+    public void updateUserPlayTime(LocalDateTime playEndTime) {
+        this.playEndTime = playEndTime;
+    }
+}

--- a/src/main/java/com/project/trysketch/repository/PlayTimeRepository.java
+++ b/src/main/java/com/project/trysketch/repository/PlayTimeRepository.java
@@ -1,0 +1,11 @@
+package com.project.trysketch.repository;
+
+import com.project.trysketch.entity.UserPlayTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PlayTimeRepository extends JpaRepository<UserPlayTime, Integer> {
+
+    List<UserPlayTime> findAllByGameRoomId(Long gameRoomId);
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feature/117-> develop

### 변경 사항
- 기존 로그인 횟수 관련 업적만 가능 → 업적 3종 기능 구현 완료
- 유저의 플레이타임 연산을 위한 UserPlayTime 엔티티 생성 + 그에 따른 repo 생성
- GameRoomUser - UserPlayTime 간 OneToOne 연관관계 형성


### 테스트 결과
서버 테스트 결과 이상 없습니다.
